### PR TITLE
added originalQuery option

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -25,7 +25,8 @@ module.exports = function(options) {
     cacheKeyFn: null,
     timeout: 5000,
     maxRedirects: 5,
-    gzip: true
+    gzip: true,
+    originalQuery: false
   });
 
   return function(req, res, next) {

--- a/lib/request-options.js
+++ b/lib/request-options.js
@@ -50,12 +50,18 @@ module.exports = function(req, options, limits) {
   // Substitute the actual values using both those from the incoming
   // params as well as those configured in the options. Values in the
   // options take precedence.
-  requestOptions.url = formatUrl({
+
+  // If options.originalQuery is true, ignore the above and just
+  // use the original raw querystring as the search
+
+  requestOptions.url = formatUrl(_.extend({
     protocol: parsedUrl.protocol,
     host: parsedUrl.host,
-    pathname: pathname,
-    query: _.extend({}, querystring.parse(parsedUrl.query), req.query, options.query)
-  });
+    pathname: pathname
+  }, options.originalQuery ?
+    {search: req.url.replace(/^.+\?/, '')} :
+    {query: _.extend({}, querystring.parse(parsedUrl.query), req.query, options.query)}
+  ));
 
   requestOptions.headers = {};
 


### PR DESCRIPTION
I had a route with nested parameters, like `?param[a][]=val`
The `formatUrl()` call in `[request-options.js](https://github.com/4front/express-request-proxy/blob/master/lib/request-options.js#L53)` was stripping them bare, as [querystring](https://nodejs.org/api/querystring.html) doesn't support nested parameters.

My solution, which is working for me, is an additional option, `originalQuery`, which just ignores all of the other parameters and uses the original request's, raw querystring as the `search` parameter in the call to `formatUrl()`