### PR TITLE
Use host header to populate x-forwarded-host and x-forwarded-port

### DIFF
--- a/lib/request-options.js
+++ b/lib/request-options.js
@@ -77,8 +77,19 @@ module.exports = function(req, options, limits) {
     requestOptions.headers['x-forwarded-for'] = req.ip;
   }
 
+  if (req.headers && req.headers.host) {
+      var hostSplit = req.headers.host.split(':');
+      var host = hostSplit[0];
+      var port = hostSplit[1];
+
+      if (port) {
+          requestOptions.headers['x-forwarded-port'] = port;
+      }
+
+      requestOptions.headers['x-forwarded-host'] = host;
+  }
+
   requestOptions.headers['x-forwarded-proto'] = req.secure ? 'https' : 'http';
-  requestOptions.headers['x-forwarded-port'] = req.secure ? '443' : '80';
 
   // Default to accepting gzip encoding
   if (!requestOptions.headers['accept-encoding']) {

--- a/test/request-options.js
+++ b/test/request-options.js
@@ -177,13 +177,28 @@ describe('requestOptions', function() {
     assert.equal(opts.headers['x-forwarded-for'], req.ip);
     assert.equal(opts.headers['accept-encoding'], 'gzip');
     assert.equal(opts.headers['x-forwarded-proto'], 'https');
-    assert.equal(opts.headers['x-forwarded-port'], '443');
 
     req.secure = false;
     opts = requestOptions(req, endpointOptions);
 
     assert.equal(opts.headers['x-forwarded-proto'], 'http');
-    assert.equal(opts.headers['x-forwarded-port'], '80');
+  });
+
+  it('default headers appended host and port', function() {
+    var req = {
+      headers: {
+          host: 'localhost:8080'
+      }
+    };
+
+    var endpointOptions = {
+      url: 'http://someapi.com',
+      cache: {}
+    };
+
+    var opts = requestOptions(req, endpointOptions);
+    assert.equal(opts.headers['x-forwarded-host'], 'localhost');
+    assert.equal(opts.headers['x-forwarded-port'], '8080');
   });
 
   it('cannot exceed limit options', function() {


### PR DESCRIPTION
The backend behind my proxy requires a x-forwarded-host and x-forwarded-port header. This pull request adds the relative information from the host header.