### PR TITLE
Fix lint errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 .DS_Store
 *.log
+.eslintcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ node_js:
 matrix:
   allow_failures:
   fast_finish: true
-script: "npm run-script test-travis"
+script: "npm run test-travis && npm run lint"
 after_script: "npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls"

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -15,6 +15,7 @@ var discardApiResponseHeaders = ['set-cookie', 'content-length'];
 // in cached responses.
 var headersToPreserveInCache = ['content-type'];
 
+/* eslint-disable consistent-return */
 module.exports = function(options) {
   options = _.defaults(options || {}, {
     ensureAuthenticated: false,
@@ -181,7 +182,11 @@ module.exports = function(options) {
         // Store the headers as a separate cache entry
         if (_.isEmpty(headersToKeep) === false) {
           debug('writing original headers to cache');
-          options.cache.setex(cacheKey + '__headers', options.cacheMaxAge, JSON.stringify(headersToKeep));
+          options.cache.setex(
+              cacheKey + '__headers',
+              options.cacheMaxAge,
+              JSON.stringify(headersToKeep)
+          );
         }
 
         debug('cache api response for %s seconds', options.cacheMaxAge);

--- a/lib/request-options.js
+++ b/lib/request-options.js
@@ -27,7 +27,7 @@ module.exports = function(req, options, limits) {
       }
     }
     if (_.isNumber(limits.maxRedirects)) {
-      if (_.isNumber(options.maxRedirects) === false || options.maxRedirects > limits.maxRedirects) {
+      if (!_.isNumber(options.maxRedirects) || options.maxRedirects > limits.maxRedirects) {
         requestOptions.maxRedirects = limits.maxRedirects;
       }
     }
@@ -78,15 +78,15 @@ module.exports = function(req, options, limits) {
   }
 
   if (req.headers && req.headers.host) {
-      var hostSplit = req.headers.host.split(':');
-      var host = hostSplit[0];
-      var port = hostSplit[1];
+    var hostSplit = req.headers.host.split(':');
+    var host = hostSplit[0];
+    var port = hostSplit[1];
 
-      if (port) {
-          requestOptions.headers['x-forwarded-port'] = port;
-      }
+    if (port) {
+      requestOptions.headers['x-forwarded-port'] = port;
+    }
 
-      requestOptions.headers['x-forwarded-host'] = host;
+    requestOptions.headers['x-forwarded-host'] = host;
   }
 
   requestOptions.headers['x-forwarded-proto'] = req.secure ? 'https' : 'http';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha --reporter spec --bail --check-leaks test/",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
-    "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+    "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+    "lint": "eslint --cache ./lib index.js"
   },
   "repository": {
     "type": "git",
@@ -43,7 +44,7 @@
   "devDependencies": {
     "compression": "^1.6.0",
     "dash-assert": "^1.0.2",
-    "eslint": "^1.9.0",
+    "eslint": "^2.3.0",
     "eslint-config-4front": "^1.0.1",
     "express": "^4.11.1",
     "istanbul": "^0.3.5",


### PR DESCRIPTION
I added an editorconfig so atom does the right thing with indents.
I added a eslint to the run scripts so you can now do:

```
npm run lint
``` 

I fixed all of the lint errors using your preferred eslint config and made travis run the lint check. 