### PR TITLE
Add followRedirect as a valid request option

### DIFF
--- a/lib/request-options.js
+++ b/lib/request-options.js
@@ -10,7 +10,7 @@ var CACHE_HEADERS = ['if-none-match', 'if-modified-since'];
 
 // Returns an options object that can be fed to the request module.
 module.exports = function(req, options, limits) {
-  var requestOptions = _.pick(options, 'method', 'timeout', 'maxRedirects', 'proxy');
+  var requestOptions = _.pick(options, 'method', 'timeout', 'maxRedirects', 'proxy', 'followRedirect');
 
   // If an explicit method was not specified on the options, then use the
   // method of the inbound request to the proxy.

--- a/test/request-options.js
+++ b/test/request-options.js
@@ -272,4 +272,23 @@ describe('requestOptions', function() {
     var opts = requestOptions(req, endpointOptions);
     assert.equal(opts.method, endpointOptions.method);
   });
+
+  it('allows followRedirect from the options', function() {
+    var req = {
+      followRedirect: undefined,
+      method: 'get'
+    };
+
+    var endpointOptions = {
+      url: 'http://someapi.com',
+      followRedirect: true
+    };
+
+    var opts = requestOptions(req, endpointOptions);
+    assert.equal(opts.followRedirect, endpointOptions.followRedirect);
+
+    endpointOptions.followRedirect = false;
+    opts = requestOptions(req, endpointOptions);
+    assert.equal(opts.followRedirect, endpointOptions.followRedirect);
+  });
 });


### PR DESCRIPTION
Sometimes you want the browser to receive the redirect rather than the proxy following it.
This option allows the 'followRedirect' option to be passed through to the underlying request.