### PR TITLE
Set timeout error code to 504

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -262,7 +262,7 @@ module.exports = function(options) {
   function unhandledApiError(err, next) {
     debug('unhandled API error: %s', err.code);
     if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
-      return next(Error.http(408, 'API call timed out'));
+      return next(Error.http(504, 'API call timed out'));
     }
     return next(err);
   }

--- a/test/errors.js
+++ b/test/errors.js
@@ -29,13 +29,13 @@ describe('timeout', function() {
       .end(done);
   });
 
-  it('api timeout returns 408', function(done) {
+  it('api timeout returns 504', function(done) {
     this.apiLatency = 50;
     this.proxyOptions.timeout = 20;
 
     supertest(this.server)
       .get('/proxy')
-      .expect(408, done);
+      .expect(504, done);
   });
 
   it('api returns 408 when instructed to cache', function(done) {


### PR DESCRIPTION
The issue here is that the HTTP specification for 408 allows clients to repeat the request. It seems that modern browsers (i.e. Chrome) will retry a few times before providing the error code to the client application.
https://tools.ietf.org/html/rfc2068#section-10.4.9
vs
https://tools.ietf.org/html/rfc2068#section-10.5.5

Adresses #19 