### PR TITLE
Handle original query for URLs without ? character

### DIFF
--- a/lib/request-options.js
+++ b/lib/request-options.js
@@ -55,13 +55,17 @@ module.exports = function(req, options, limits) {
 
   // If options.originalQuery is true, ignore the above and just
   // use the original raw querystring as the search
+  var originalQuery = "";
+  if (req.url && req.url.indexOf("?") !== -1) {
+    originalQuery = req.url.replace(/^.+\?/, "");
+  }
 
   requestOptions.url = formatUrl(_.extend({
     protocol: parsedUrl.protocol,
     host: parsedUrl.host,
     pathname: pathname
   }, options.originalQuery ?
-    {search: req.url.replace(/^.+\?/, '')} :
+    {search: originalQuery} :
     {query: _.extend({}, querystring.parse(parsedUrl.query), req.query, options.query)}
   ));
 


### PR DESCRIPTION
When using `originalQuery: true` option, if the URL does not have a `?` character, the regex `/^.+\?/` causes the entire request URL to be set as the `search` parameter. This change checks for the presence of a `?` character in the string, and sets an empty string as the search parameter if not present.

At present, the query logic does not account for URLs without a `?` character.

For example, a request with URL `http://example.com/foo` with option `originalQuery: true` would be transformed to `https://my-proxy-destination.com/bar?http://example.com/foo`, while `http://example.com/foo?id=4` would correctly be transformed to `https://my-proxy-destination.com/bar?id=4

The correct behaviour for URLs without a query string (and therefore no `?` character) is that no query should be set to the proxy URL.