### PR TITLE
If the error handler function is not passed to 'request' then it can throw an uncatchable exception.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -15,8 +15,8 @@ require('simple-errors');
 var headersToPreserveInCache = ['content-type'];
 
 /* eslint-disable consistent-return */
-module.exports = function(options) {
-  
+module.exports = function(options, errorhandler) {
+
   // Allow discarding response headers to be configurable
   var discardApiResponseHeaders = options.discardApiResponseHeaders || ['set-cookie', 'content-length'];
 
@@ -81,10 +81,10 @@ module.exports = function(options) {
     var originalApiRequest;
     if (is.hasBody(req)) {
       debug('piping req body to remote http endpoint');
-      originalApiRequest = request(apiRequestOptions);
+      originalApiRequest = request(apiRequestOptions, errorhandler);
       apiRequest = req.pipe(originalApiRequest);
     } else {
-      apiRequest = request(apiRequestOptions);
+      apiRequest = request(apiRequestOptions, errorhandler);
       originalApiRequest = apiRequest;
     }
 


### PR DESCRIPTION
Since the library is not allowing us to pass an error handler we are unable to catch the ECONNREFUSED error. This error cannot be caught using a try catch block and makes our server crash. Please consider merging this PR.